### PR TITLE
Draft: Additional Fields Support

### DIFF
--- a/ninja_schema/orm/model_schema.py
+++ b/ninja_schema/orm/model_schema.py
@@ -319,13 +319,14 @@ class ModelSchemaMetaclass(ModelMetaclass):
             and config_instance
             and not config_instance.abstract
         ):
+            annotations = namespace.setdefault("__annotations__", {})
+
             if config_instance.additional:
                 for additional in config_instance.additional:
                     namespace["__annotations__"][additional["field_name"]] = additional["field_type"]
                     if "field_default" in additional:
                         namespace[additional["field_name"]] = additional["field_default"]
             
-            annotations = namespace.get("__annotations__", {})
             try:
                 fields = list(config_instance.model_fields())
             except AttributeError as exc:

--- a/ninja_schema/orm/model_schema.py
+++ b/ninja_schema/orm/model_schema.py
@@ -221,6 +221,7 @@ class ModelSchemaConfig(BaseConfig):
         self.optional = (
             {ALL_FIELDS} if _optional == ALL_FIELDS else set(_optional or ())
         )
+        self.additional = getattr(options, "additional", None)
         self.depth = int(getattr(options, "depth", 0))
         self.schema_class_name = schema_class_name
         if not self.abstract:
@@ -318,6 +319,11 @@ class ModelSchemaMetaclass(ModelMetaclass):
             and config_instance
             and not config_instance.abstract
         ):
+            if config_instance.additional:
+                for additional in config_instance.additional:
+                    namespace["__annotations__"][additional["field_name"]] = additional["field_type"]
+                    namespace[additional["field_name"]] = additional["field_default"]
+            
             annotations = namespace.get("__annotations__", {})
             try:
                 fields = list(config_instance.model_fields())

--- a/ninja_schema/orm/model_schema.py
+++ b/ninja_schema/orm/model_schema.py
@@ -322,7 +322,8 @@ class ModelSchemaMetaclass(ModelMetaclass):
             if config_instance.additional:
                 for additional in config_instance.additional:
                     namespace["__annotations__"][additional["field_name"]] = additional["field_type"]
-                    namespace[additional["field_name"]] = additional["field_default"]
+                    if "field_default" in additional:
+                        namespace[additional["field_name"]] = additional["field_default"]
             
             annotations = namespace.get("__annotations__", {})
             try:

--- a/tests/test_model_schema.py
+++ b/tests/test_model_schema.py
@@ -8,6 +8,38 @@ from tests.models import Event
 
 
 class TestModelSchema:
+    def test_schema_additional_fields(self):
+        class EventSchema(ModelSchema):
+            class Config:
+                model = Event
+                include = ["id"]
+                additional = [
+                    {
+                        "field_name": "custom_int_field",
+                        "field_type": int,
+                    }, 
+                    {
+                        "field_name": "custom_str_field",
+                        "field_type": str,
+                        "field_default": "default",
+                    },
+                    {
+                        "field_name": "custom_bool_field",
+                        "field_type": bool | None,
+                    }
+                ]
+        assert EventSchema.schema() == {
+            "title": "EventSchema",
+            "type": "object",
+            "properties": {
+                "custom_int_field": {"title": "Custom Int Field", "type": "integer"},
+                "custom_str_field": {"title": "Custom Str Field", "type": "string", "default": "default"},
+                "custom_bool_field": {"title": "Custom Bool Field", "type": "boolean"},
+                "id": {"title": "Id", "type": "integer"},
+            },
+            "required": ["id", "custom_int_field"],
+        }
+
     def test_schema_include_fields(self):
         class EventSchema(ModelSchema):
             class Config:


### PR DESCRIPTION
This PR adds support for adding additional Fields on an model, which can be used and are seen in api docs.


```python
class CustomSchema(ModelSchema):
    class Config:
        model = CustomModel
        additional = [{"field_name": "custom_int_field", "field_type": int, "field_default": 3}]
```

this PR is needed for the PR in django-ninja-jwt

In certain circumstances, one need to add fields on existing Schema. In this case to add custom fields to a django-ninja-jwt serializer - which are needed to be used in that user_authentication_rule
