### PR TITLE
Fix TextChoices conversion to Enum

### DIFF
--- a/ninja_schema/orm/utils/converter.py
+++ b/ninja_schema/orm/utils/converter.py
@@ -225,7 +225,7 @@ def construct_field_info(
             f"{field.name.title().replace('_', '')}Enum",
             named_choices,
             module=__module__,
-            type=str,
+            type=type(named_choices[0][1]),
         )
         is_custom_type = True
 

--- a/ninja_schema/orm/utils/converter.py
+++ b/ninja_schema/orm/utils/converter.py
@@ -225,6 +225,7 @@ def construct_field_info(
             f"{field.name.title().replace('_', '')}Enum",
             named_choices,
             module=__module__,
+            type=str,
         )
         is_custom_type = True
 

--- a/tests/test_v1_pydantic/test_custom_fields.py
+++ b/tests/test_v1_pydantic/test_custom_fields.py
@@ -33,6 +33,7 @@ class TestCustomFields:
                     "title": "SemesterEnum",
                     "description": "An enumeration.",
                     "enum": ["1", "2", "3"],
+                    "type": "string"
                 }
             },
         }


### PR DESCRIPTION
Use `str` as base class in dynamic Enum creation for django Choices

This PR fixes a bug found in `django-ninja-extra` when using a `ModelController` and a `Model` that has a `TextChoices` in a `CharField`.

If the Enum is not based on `str`, the serialization creates the string `'Enum.option'` instead of `'option'` causing a validation error in pydantic.