### PR TITLE
Refactor clone_field method implementation

### DIFF
--- a/ninja_schema/orm/model_schema.py
+++ b/ninja_schema/orm/model_schema.py
@@ -247,9 +247,11 @@ class ModelSchemaConfig:
 
     @classmethod
     def clone_field(cls, field: FieldInfo, **kwargs: Any) -> FieldInfo:
-        field_dict = dict(field.__repr_args__())
-        field_dict.update(**kwargs)
-        new_field = FieldInfo(**field_dict)  # type: ignore
+        new_field = field._copy()
+        for key, value in kwargs.items():
+            setattr(new_field, key, value)
+        new_field.rebuild_annotation()
+        
         return new_field
 
     def model_fields(self) -> Iterator[Field]:

--- a/tests/test_v2_pydantic/test_model_schema.py
+++ b/tests/test_v2_pydantic/test_model_schema.py
@@ -227,7 +227,7 @@ class TestModelSchema:
                     "description": "",
                     "title": "Title",
                 },
-                "category": {
+                "category_id": {
                     "anyOf": [{"type": "integer"}, {"type": "null"}],
                     "default": None,
                     "description": "",


### PR DESCRIPTION
Refactor the `clone_field` method to use `_copy` and explicitly set attributes.

The previous implementation generated an incorrect annotation (`annotation=PlainRepr` instead of `annotation=NoneType`). This resulted in an invalid JSON schema and incorrect foreign key (FK) validation.

This occured when you put an FK as optional field

you can see this test in `category` attribute:

- Good  test
https://github.com/eadwinCode/ninja-schema/blob/f6bc331c2bffff9fe0dfc2a6c24ebff862819d85/tests/test_v2_pydantic/test_model_schema.py#L39
<img width="652" height="928" alt="image" src="https://github.com/user-attachments/assets/6a0c5e45-16e2-4c55-8342-f05e240efa60" />

- Bad test:
https://github.com/eadwinCode/ninja-schema/blob/f6bc331c2bffff9fe0dfc2a6c24ebff862819d85/tests/test_v2_pydantic/test_model_schema.py#L230
<img width="740" height="898" alt="image" src="https://github.com/user-attachments/assets/03e94be4-ddc1-44b3-be61-9dee552059bc" />
